### PR TITLE
/etc/profile is used in Ubuntu, not ~/.bash_profile

### DIFF
--- a/bin/rbenv-installer
+++ b/bin/rbenv-installer
@@ -56,7 +56,7 @@ if [ ! $(which rbenv) ]; then
   echo "
 Seems you still have not added 'rbenv' to the load path:
 
-# ~/.bash_profile:
+# ~/.bash_profile (or for Ubuntu, /etc/profile):
 
 export RBENV_ROOT=\"\${HOME}/.rbenv\"
 


### PR DESCRIPTION
On Ubuntu systems (mine, at least), `~/.bash_profile` is not automatically loaded, even with login shell.

Rather, the code should be placed in `/etc/profile`.